### PR TITLE
Use Presigned Urls for object creation/retrieval at S3(AWS)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,4 +44,8 @@ dependencies {
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    // S3
+    implementation platform('software.amazon.awssdk:bom:2.10.30')
+    implementation 'software.amazon.awssdk:s3'
 }

--- a/src/main/java/wolox/training/config/AWSConfig.java
+++ b/src/main/java/wolox/training/config/AWSConfig.java
@@ -1,0 +1,30 @@
+package wolox.training.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Component
+public class AWSConfig {
+
+    @Bean
+    public S3Presigner preSigner() {
+        return S3Presigner
+            .builder()
+            .credentialsProvider(awsProfileFile())
+            .region(Region.US_EAST_2)
+            .build();
+    }
+
+    @Bean
+    public AwsCredentialsProvider awsProfileFile() {
+        return ProfileCredentialsProvider
+            .builder()
+            .profileFile(ProfileFile.defaultProfileFile())
+            .build();
+    }
+}

--- a/src/main/java/wolox/training/config/SecurityConfig.java
+++ b/src/main/java/wolox/training/config/SecurityConfig.java
@@ -41,6 +41,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         web
             .ignoring()
             .antMatchers(HttpMethod.POST, "/api/books/")
-            .antMatchers(HttpMethod.POST, "/api/users/");
+            .antMatchers(HttpMethod.POST, "/api/users/")
+            .antMatchers(HttpMethod.POST, "/api/files/")
+            .antMatchers(HttpMethod.GET, "/api/files/");
     }
 }

--- a/src/main/java/wolox/training/controllers/FileController.java
+++ b/src/main/java/wolox/training/controllers/FileController.java
@@ -1,0 +1,37 @@
+package wolox.training.controllers;
+
+import javax.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import wolox.training.models.dtos.S3UploadRequest;
+import wolox.training.services.S3FileUploadService;
+
+@RestController
+@RequestMapping("/api/files/")
+public class FileController {
+
+    private final S3FileUploadService s3FileUploadService;
+
+    @Autowired
+    public FileController(S3FileUploadService s3FileUploadService) {
+        this.s3FileUploadService = s3FileUploadService;
+    }
+
+    @PostMapping("/")
+    public String createPreSignedUrl(@Valid @RequestBody S3UploadRequest request,
+        @RequestHeader("x-content-type") String contentType) {
+        return s3FileUploadService.preSignPutObjectUrl(request.getKey(), contentType);
+    }
+
+    @GetMapping("/")
+    public String readPreSignedUrl(@Valid @RequestBody S3UploadRequest request,
+        @RequestHeader("x-content-type") String contentType) {
+        return s3FileUploadService.preSignGetObjectUrl(request.getKey());
+    }
+
+}

--- a/src/main/java/wolox/training/models/dtos/S3UploadRequest.java
+++ b/src/main/java/wolox/training/models/dtos/S3UploadRequest.java
@@ -1,0 +1,13 @@
+package wolox.training.models.dtos;
+
+import javax.validation.constraints.NotEmpty;
+
+public class S3UploadRequest {
+
+    @NotEmpty
+    private String key;
+
+    public String getKey() {
+        return key;
+    }
+}

--- a/src/main/java/wolox/training/services/S3FileUploadService.java
+++ b/src/main/java/wolox/training/services/S3FileUploadService.java
@@ -1,0 +1,9 @@
+package wolox.training.services;
+
+public interface S3FileUploadService {
+
+    String preSignPutObjectUrl(String objectKey, String mimeType);
+
+    String preSignGetObjectUrl(String objectKey);
+
+}

--- a/src/main/java/wolox/training/services/impl/S3FileUploadServiceImpl.java
+++ b/src/main/java/wolox/training/services/impl/S3FileUploadServiceImpl.java
@@ -1,0 +1,75 @@
+package wolox.training.services.impl;
+
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+import wolox.training.services.S3FileUploadService;
+
+@Service
+public class S3FileUploadServiceImpl implements S3FileUploadService {
+
+    private final S3Presigner preSigner;
+
+    @Value("${aws.s3.presigned.url.duration}")
+    private Long s3PresignedDuration;
+
+    @Value("${aws.s3.bucket}")
+    private String s3BucketName;
+
+    @Value("${aws.s3.trainee.folder}")
+    private String s3TraineeFolder;
+
+    @Autowired
+    public S3FileUploadServiceImpl(S3Presigner preSigner) {
+        this.preSigner = preSigner;
+    }
+
+    @Override
+    public String preSignPutObjectUrl(String key, String mimeType) {
+        PutObjectRequest putObjectRequest = PutObjectRequest
+            .builder()
+            .bucket(s3BucketName)
+            .key(String.format("%s/%s", s3TraineeFolder, key))
+            .contentType(mimeType)
+            .build();
+
+        PutObjectPresignRequest putObjectPresignRequest = PutObjectPresignRequest
+            .builder()
+            .putObjectRequest(putObjectRequest)
+            .signatureDuration(Duration.ofSeconds(s3PresignedDuration))
+            .build();
+
+        PresignedPutObjectRequest presignedPutObjectRequest = preSigner
+            .presignPutObject(putObjectPresignRequest);
+
+        return presignedPutObjectRequest.url().toString();
+    }
+
+    @Override
+    public String preSignGetObjectUrl(String objectKey) {
+        GetObjectRequest getObjectRequest = GetObjectRequest
+            .builder()
+            .bucket(s3BucketName)
+            .key(String.format("%s/%s", s3TraineeFolder, objectKey))
+            .build();
+
+        GetObjectPresignRequest getObjectPresignRequest = GetObjectPresignRequest
+            .builder()
+            .getObjectRequest(getObjectRequest)
+            .signatureDuration(Duration.ofSeconds(s3PresignedDuration))
+            .build();
+
+        PresignedGetObjectRequest presignedGetObjectRequest = preSigner
+            .presignGetObject(getObjectPresignRequest);
+
+        return presignedGetObjectRequest.url().toString();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,7 @@ spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 server.port=8081
 
 open.library.url=https://openlibrary.org/api/books?bibkeys=ISBN:{isbn}&format=json&jscmd=data
+
+aws.s3.bucket=training-wolox-backend-upload
+aws.s3.presigned.url.duration=300
+aws.s3.trainee.folder=trainee


### PR DESCRIPTION
A better way to create and retrieve resources from the Simple Storage Service (S3) at AWS.

To implement this you have to:

1. Create an account at AWS.
2. Store AWS credentials (Access Key ID & Access Key Secret) on ~/.aws/credential files.
3. In the application.properties file setup the variables:
```
aws.s3.bucket=training-wolox-backend-upload
aws.s3.presigned.url.duration=
aws.s3.trainee.folder=
```
Those variables will be used in order to AWS SDK to work. And must be custom for each trainee.

